### PR TITLE
Frontend: Add delete question functionalities (Missing functionality: Only display delete button for admins)

### DIFF
--- a/frontend/src/components/custom/Question/DeleteQuestionButton.tsx
+++ b/frontend/src/components/custom/Question/DeleteQuestionButton.tsx
@@ -1,0 +1,38 @@
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+import { useState } from "react";
+import DeleteQuestionDialog from "./DeleteQuestionDialog";
+import { Question } from "@/models/Question";
+
+interface DeleteQuestionButtonProps {
+  question: Question;
+}
+
+const DeleteQuestionButton: React.FC<DeleteQuestionButtonProps> = ({
+  question,
+}) => {
+  const [openDialog, setOpenDialog] = useState<boolean>(false);
+
+  const handleOpenDialog = () => {
+    setOpenDialog(true);
+  };
+
+  return (
+    <>
+      <Button
+        onClick={handleOpenDialog}
+        className="bg-red-400 hover:bg-red-500"
+        size="sm"
+      >
+        <X size={20} />
+      </Button>
+      <DeleteQuestionDialog
+        open={openDialog}
+        setOpen={setOpenDialog}
+        question={question}
+      />
+    </>
+  );
+};
+
+export default DeleteQuestionButton;

--- a/frontend/src/components/custom/Question/DeleteQuestionDialog.tsx
+++ b/frontend/src/components/custom/Question/DeleteQuestionDialog.tsx
@@ -1,0 +1,80 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+} from "@/components/ui/dialog";
+import { SuccessObject, callFunction } from "@/lib/utils";
+import { Question } from "@/models/Question";
+import { DialogDescription, DialogTitle } from "@radix-ui/react-dialog";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+
+interface DeleteQuestionCardProps {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  question: Question;
+}
+
+const DeleteQuestionDialog: React.FC<DeleteQuestionCardProps> = ({
+  open,
+  setOpen,
+  question,
+}) => {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const handleCloseDialog = () => {
+    setOpen(false);
+  };
+
+  const handleDelete = async () => {
+    const result: SuccessObject = await callFunction(
+      "delete-question",
+      "DELETE",
+      { id: question.id }
+    );
+
+    if (result.success) {
+      alert("Question deleted successfully! Refresh Page to see changes.");
+    } else {
+      alert("Failed to delete question. Please try again.");
+    }
+    setIsLoading(false);
+    handleCloseDialog();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="justify-center">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-semibold leading-none tracking-tight">
+            Delete Question: {question.title}
+          </DialogTitle>
+          <DialogDescription className="text-sm text-muted-foreground">
+            Deletion is non-reversable, please double check before deleting.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col items-center justify-center">
+          <p>Are you sure you want to delete this question?</p>
+          <b className="text-xl my-2 text-orange-500">{question.title}</b>
+        </div>
+        <DialogFooter>
+          <Button
+            onClick={handleDelete}
+            disabled={isLoading}
+            className="bg-red-500"
+          >
+            {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : ""}
+            Delete
+          </Button>
+          <Button onClick={handleCloseDialog} className="bg-slate-400">
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default DeleteQuestionDialog;

--- a/frontend/src/components/custom/QuestionTable/columns.tsx
+++ b/frontend/src/components/custom/QuestionTable/columns.tsx
@@ -3,6 +3,7 @@ import { IDictionary, isSubset } from "../../../lib/utils";
 import { DataTableColumnHeader } from "@/components/ui/table/data-table-column-header";
 import { Question, Difficulty } from "@/models/Question";
 import QuestionDialog from "../Question/QuestionDialog";
+import DeleteQuestionButton from "../Question/DeleteQuestionButton";
 
 const difficultyLevels: IDictionary<number> = {
   Easy: 1,
@@ -34,6 +35,15 @@ const getDifficultyClass = (difficulty: string) => {
 };
 
 export const columns: ColumnDef<Question>[] = [
+  {
+    id: "actions",
+    size: 10,
+    maxSize: 10,
+    cell: ({ row }) => {
+      const question = row.original;
+      return <DeleteQuestionButton question={question} />;
+    },
+  },
   {
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Topics" />

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,16 +1,16 @@
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { Cross2Icon } from "@radix-ui/react-icons"
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Cross2Icon } from "@radix-ui/react-icons";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Dialog = DialogPrimitive.Root
+const Dialog = DialogPrimitive.Root;
 
-const DialogTrigger = DialogPrimitive.Trigger
+const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = DialogPrimitive.Portal
+const DialogPortal = DialogPrimitive.Portal;
 
-const DialogClose = DialogPrimitive.Close
+const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -24,8 +24,8 @@ const DialogOverlay = React.forwardRef<
     )}
     {...props}
   />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
@@ -48,8 +48,8 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({
   className,
@@ -62,8 +62,8 @@ const DialogHeader = ({
     )}
     {...props}
   />
-)
-DialogHeader.displayName = "DialogHeader"
+);
+DialogHeader.displayName = "DialogHeader";
 
 const DialogFooter = ({
   className,
@@ -76,8 +76,8 @@ const DialogFooter = ({
     )}
     {...props}
   />
-)
-DialogFooter.displayName = "DialogFooter"
+);
+DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -91,8 +91,8 @@ const DialogTitle = React.forwardRef<
     )}
     {...props}
   />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
@@ -103,8 +103,8 @@ const DialogDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
@@ -117,4 +117,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-}
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -55,8 +55,15 @@ export async function callFunction(
       throw new Error(`Error: ${response.status} - ${response.statusText}`);
     }
 
-    // Parse and return the JSON data
-    const result = await response.json();
+    // Check for empty response
+    const data = await response.text();
+
+    if (!data) {
+      return { success: true };
+    }
+
+    // Parse the JSON data
+    const result = JSON.parse(data);
 
     return { success: true, data: result };
   } catch (error: any) {


### PR DESCRIPTION
1) Currently only updates table on refresh

### Delete Buttons added to side of each table rows
![image](https://github.com/user-attachments/assets/98e95927-8d54-4b60-866d-b52d85064bdb)

### Delete Dialog
![image](https://github.com/user-attachments/assets/b1015570-0a90-44a7-8c43-c3e6bf45499c)

### On successful Deletion
![image](https://github.com/user-attachments/assets/06378932-2a8f-481e-b87a-760e5a047001)
