### PR TITLE
[Fix] Question page frontend overflow

### DIFF
--- a/frontend/src/components/custom/QuestionTable/QuestionTable.tsx
+++ b/frontend/src/components/custom/QuestionTable/QuestionTable.tsx
@@ -23,7 +23,7 @@ function QuestionTable() {
 
   // Return a loading indicator or the table once data is available
   return (
-    <div className="container mx-auto py-10">
+    <div className="container mx-auto">
       {loading ? (
         <p>Loading...</p> // Show loading text or spinner
       ) : (

--- a/frontend/src/views/QuestionPageView.tsx
+++ b/frontend/src/views/QuestionPageView.tsx
@@ -22,7 +22,10 @@ const QuestionPageView: React.FC = () => {
   };
 
   return (
-    <main className="h-screen w-screen p-5">
+    <main
+      className="h-screen w-screen p-5"
+      style={{ height: "100%", backgroundColor: "white" }}
+    >
       <div className="flex items-center justify-between mb-4">
         <Title title="Question Bank" />
         <img
@@ -58,7 +61,10 @@ const QuestionPageView: React.FC = () => {
       <Separator className="my-2" />
 
       <div className="grid grid-cols-3 gap-4">
-        <div className="p-4 col-span-3 md:col-span-1 rounded-lg shadow-lg">
+        <div
+          className="p-4 col-span-3 md:col-span-1 rounded-lg shadow-lg"
+          style={{ height: "100vh" }}
+        >
           <MatchingOptions />
         </div>
         <div className="p-4 col-span-3 md:col-span-2 rounded-lg shadow-lg">


### PR DESCRIPTION
## this branches out from jr's PR #68
changes:

- set this \<div\>'s height to 100 viewport height (100vh) so it doesnt overflow
- the red border was generated using `style={{border: "5px solid red"}}`

![image](https://github.com/user-attachments/assets/365e0ae2-a0d3-4fa4-95e9-48138016643c)

<br>

- removed `py-10` extra padding causing this extra space
- the red border here is drawn on paint.exe

![image](https://github.com/user-attachments/assets/d99b3976-8b4f-471c-a58a-9e239269354d)

<br>

- the questions/pagination is designed to fit 10 questions per page, would be ugly to squeeze it into a scrollable, so instead i changed the entire background colour to white so it doesnt make a hard switch from white to gray

![image](https://github.com/user-attachments/assets/345025f6-b1b9-43d9-b331-28f2907bf260)

## after changes

https://github.com/user-attachments/assets/28994d39-32d7-40ec-82d3-a78e71abdadc

