### PR TITLE
[Fix] Coordinate backend error messages structure to fit with how the frontend handles it

### DIFF
--- a/backend/collab_service/controllers/executeCodeController.js
+++ b/backend/collab_service/controllers/executeCodeController.js
@@ -28,7 +28,7 @@ const executeCode = async (req, res) => {
 		return response.data;
 	} catch (error) {
         console.error("Error executing code:", error); // Log the full error object
-		res.status(500).send(error.message);
+		res.status(500).json({ message: error.message });
 	}
 };
 

--- a/backend/question_service/controllers/questionController.js
+++ b/backend/question_service/controllers/questionController.js
@@ -11,7 +11,7 @@ const getAllQuestions = async (req, res) => {
     }));
     res.status(200).json(questions);
   } catch (error) {
-    res.status(500).send(error.message);
+    res.status(500).json({ message: error.message });
   }
 };
 
@@ -36,7 +36,7 @@ const getQuestionsOfTopicAndDifficulty = async (req, res) => {
     }));
     res.status(200).json(questions);
   } catch (error) {
-    res.status(500).send(error.message);
+    res.status(500).json({ message: error.message });
   }
 };
 
@@ -100,7 +100,7 @@ const createQuestion = async (req, res) => {
       .status(201)
       .json({ id: newQuestionRef.id, ...questionDataWithDateCreated });
   } catch (error) {
-    res.status(500).send(error.message);
+    res.status(500).json({ message: error.message });
   }
 };
 
@@ -161,7 +161,7 @@ const editQuestion = async (req, res) => {
     });
     res.status(200).send();
   } catch (error) {
-    res.status(500).send(error.message);
+    res.status(500).json({ message: error.message });
   }
 };
 
@@ -177,7 +177,7 @@ const deleteQuestion = async (req, res) => {
     await questionsRef.delete();
     res.status(204).send();
   } catch (error) {
-    res.status(500).send(error.message);
+    res.status(500).json({ message: error.message });
   }
 };
 

--- a/frontend/src/components/custom/Question/AddQuestionCard.tsx
+++ b/frontend/src/components/custom/Question/AddQuestionCard.tsx
@@ -5,7 +5,11 @@ import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
 import { SingleSelect } from "@/components/ui/single-select";
 import { Textarea } from "@/components/ui/textarea";
-import { HTTP_SERVICE_QUESTION, SuccessObject, callFunction } from "@/lib/utils";
+import {
+  HTTP_SERVICE_QUESTION,
+  SuccessObject,
+  callFunction,
+} from "@/lib/utils";
 import {
   Difficulty,
   Question,
@@ -104,6 +108,7 @@ const AddQuestionCard: React.FC<AddQuestionCardProps> = ({ onCreate }) => {
               name="title"
               type="text"
               placeholder="Type your question title here."
+              maxLength={1000}
               required
               onChange={handleInputChange}
             />
@@ -115,6 +120,7 @@ const AddQuestionCard: React.FC<AddQuestionCardProps> = ({ onCreate }) => {
               name="description"
               placeholder="Type your question description here."
               className="resize-none"
+              maxLength={1000}
               required
               onChange={
                 handleInputChange as unknown as ChangeEventHandler<HTMLTextAreaElement> // Bad practice but necessary for now

--- a/frontend/src/components/custom/Question/EditQuestionCard.tsx
+++ b/frontend/src/components/custom/Question/EditQuestionCard.tsx
@@ -5,7 +5,11 @@ import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multi-select";
 import { SingleSelect } from "@/components/ui/single-select";
 import { Textarea } from "@/components/ui/textarea";
-import { HTTP_SERVICE_QUESTION, SuccessObject, callFunction } from "@/lib/utils";
+import {
+  HTTP_SERVICE_QUESTION,
+  SuccessObject,
+  callFunction,
+} from "@/lib/utils";
 import {
   Difficulty,
   Question,
@@ -112,6 +116,7 @@ const EditQuestionCard: React.FC<EditQuestionCardProps> = ({
               type="text"
               placeholder="Type your question title here."
               value={questionData.title}
+              maxLength={1000}
               required
               onChange={handleInputChange}
             />
@@ -125,6 +130,7 @@ const EditQuestionCard: React.FC<EditQuestionCardProps> = ({
               value={questionData.description}
               className="resize-none"
               required
+              maxLength={1000}
               onChange={
                 handleInputChange as unknown as ChangeEventHandler<HTMLTextAreaElement> // Bad practice but necessary for now
               }


### PR DESCRIPTION
Currently, some backend error messages were not aligned with the frontend handling, resulting in the error messages not displaying correctly to the user.

This needs to be changed so that the user knows what went wrong with his action and improve overall UX.

Thus, this pull request aims to do the following:
* Coordinate backend error messages structure to fit with how the frontend handles it