### PR TITLE
[Fix] Chatbox height + feature additions

### DIFF
--- a/frontend/src/views/CollabPageView.tsx
+++ b/frontend/src/views/CollabPageView.tsx
@@ -139,7 +139,7 @@ const CollabPageView: React.FC = () => {
       newSocket.on("userLeft", ({ userId }) => {
         alert(`User ${userId} has left the session.`);
       });
-      
+
       newSocket.on("messageReceived", (data) => {
         setMessages((prevMessages) => [
           ...prevMessages,
@@ -292,7 +292,7 @@ const CollabPageView: React.FC = () => {
           {/* top-left question box */}
           <div
             style={{
-              flex: 6, // Takes up 60% vertically of the left side
+              flexBasis: "60%", // Takes up 60% vertically of the left side
               alignItems: "flex-start", // Aligns the title and description to the left
               padding: "20px",
               border: "2px solid lightgrey", // Adds a border
@@ -305,57 +305,57 @@ const CollabPageView: React.FC = () => {
               {questionData.title}
             </h2>
 
-          {/* tags (difficulty & topics) */}
-          <div
-            style={{
-              marginTop: "15px",
-              marginBottom: "15px",
-              display: "flex",
-              flexWrap: "wrap",
-              gap: "10px",
-            }}
-          >
-            <Badge>{questionData.difficulty}</Badge>
-            {questionData.topics.map((topic, index) => (
-              <Badge key={index} variant="outline">
-                {topic}
-              </Badge>
-            ))}
-          </div>
+            {/* tags (difficulty & topics) */}
+            <div
+              style={{
+                marginTop: "15px",
+                marginBottom: "15px",
+                display: "flex",
+                flexWrap: "wrap",
+                gap: "10px",
+              }}
+            >
+              <Badge>{questionData.difficulty}</Badge>
+              {questionData.topics.map((topic, index) => (
+                <Badge key={index} variant="outline">
+                  {topic}
+                </Badge>
+              ))}
+            </div>
 
-          {/* description */}
-          <p>{questionData.description}</p>
+            {/* description */}
+            <p>{questionData.description}</p>
 
-          {/* examples */}
-          <div style={{ marginTop: "35px" }}>
-            {questionData.examples.map((example, index) => (
-              <div key={index} style={{ marginBottom: "20px" }}>
-                <p style={{ marginBottom: "10px" }}>
-                  <strong>Example {index + 1}:</strong>
-                </p>
-                <div
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "10px",
-                  }}
-                >
-                  <blockquote
+            {/* examples */}
+            <div style={{ marginTop: "35px" }}>
+              {questionData.examples.map((example, index) => (
+                <div key={index} style={{ marginBottom: "20px" }}>
+                  <p style={{ marginBottom: "10px" }}>
+                    <strong>Example {index + 1}:</strong>
+                  </p>
+                  <div
                     style={{
-                      paddingLeft: "10px",
-                      borderLeft: "5px solid #d0d7de",
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: "10px",
                     }}
                   >
-                    <pre>
-                      <strong>Input:</strong> {example.input}
-                    </pre>
-                    <pre>
-                      <strong>Output:</strong> {example.output}
-                    </pre>
-                  </blockquote>
+                    <blockquote
+                      style={{
+                        paddingLeft: "10px",
+                        borderLeft: "5px solid #d0d7de",
+                      }}
+                    >
+                      <pre>
+                        <strong>Input:</strong> {example.input}
+                      </pre>
+                      <pre>
+                        <strong>Output:</strong> {example.output}
+                      </pre>
+                    </blockquote>
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
 
               {/* constraints */}
               <div style={{ marginTop: "35px" }}>
@@ -372,7 +372,8 @@ const CollabPageView: React.FC = () => {
           {/* bottom-left chatbox */}
           <div
             style={{
-              flex: 4, // Takes up 40% vertically of the left side
+              flexBasis: "40%", // Takes up 40% vertically of the left side
+              maxHeight: "40%",
               marginTop: "15px",
               border: "2px solid lightgrey",
               borderRadius: "10px",
@@ -391,7 +392,8 @@ const CollabPageView: React.FC = () => {
             </h2>
             <div
               style={{
-				height: "50%",
+                height: "50%",
+                maxHeight: "50%",
                 overflowY: "scroll",
                 border: "1px solid #d0d7de",
                 borderRadius: "5px",

--- a/frontend/src/views/CollabPageView.tsx
+++ b/frontend/src/views/CollabPageView.tsx
@@ -248,6 +248,15 @@ const CollabPageView: React.FC = () => {
     }
   };
 
+  // ref to keep chatbox scroll at the bottom
+  const chatboxRef = useRef<HTMLDivElement>(null);
+  // Update the scroll position to bottom when content changes
+  useEffect(() => {
+    if (chatboxRef.current) {
+      chatboxRef.current.scrollTop = chatboxRef.current.scrollHeight;
+    }
+  });
+
   return (
     <main
       style={{
@@ -401,6 +410,7 @@ const CollabPageView: React.FC = () => {
                 marginBottom: "10px",
                 backgroundColor: "#f9f9f9",
               }}
+              ref={chatboxRef}
             >
               {messages.map((msg, index) => (
                 <p key={index} style={{ margin: "5px 0" }}>
@@ -410,7 +420,7 @@ const CollabPageView: React.FC = () => {
             </div>
             <div style={{ display: "flex", gap: "10px" }}>
               <Textarea
-                style={{ flex: 1 }}
+                style={{ flex: 1, overflowY: "scroll" }}
                 value={message}
                 onChange={(e) => setMessage(e.target.value)}
                 placeholder="Type your message here..."

--- a/frontend/src/views/CollabPageView.tsx
+++ b/frontend/src/views/CollabPageView.tsx
@@ -258,7 +258,7 @@ const CollabPageView: React.FC = () => {
   });
 
   // chatbox: if user presses Enter key, send message
-  const handleKeyDown = (event) => {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Enter') {
       event.preventDefault(); // Prevents the default behavior of adding a new line
       handleMessageSend(); // Call your function here

--- a/frontend/src/views/CollabPageView.tsx
+++ b/frontend/src/views/CollabPageView.tsx
@@ -259,7 +259,7 @@ const CollabPageView: React.FC = () => {
 
   // chatbox: if user presses Enter key, send message
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === 'Enter') {
+    if (event.key === "Enter") {
       event.preventDefault(); // Prevents the default behavior of adding a new line
       handleMessageSend(); // Call your function here
     }
@@ -428,7 +428,7 @@ const CollabPageView: React.FC = () => {
             </div>
             <div style={{ display: "flex", gap: "10px" }}>
               <Textarea
-                style={{ flex: 1, overflowY: "scroll" }}
+                style={{ flex: 1 }}
                 value={message}
                 onChange={(e) => setMessage(e.target.value)}
                 onKeyDown={handleKeyDown}

--- a/frontend/src/views/CollabPageView.tsx
+++ b/frontend/src/views/CollabPageView.tsx
@@ -257,6 +257,14 @@ const CollabPageView: React.FC = () => {
     }
   });
 
+  // chatbox: if user presses Enter key, send message
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault(); // Prevents the default behavior of adding a new line
+      handleMessageSend(); // Call your function here
+    }
+  };
+
   return (
     <main
       style={{
@@ -423,6 +431,7 @@ const CollabPageView: React.FC = () => {
                 style={{ flex: 1, overflowY: "scroll" }}
                 value={message}
                 onChange={(e) => setMessage(e.target.value)}
+                onKeyDown={handleKeyDown}
                 placeholder="Type your message here..."
               />
               <Button onClick={handleMessageSend}>Send</Button>


### PR DESCRIPTION
changes:
- set chatbox maxHeight s.t. when overflows, it doesnt shift upwards
- set scroll to always be at the bottom to see the latest message
  - previously if more messages are sent until overflow, it stays at the top
- when 'enter' key is pressed, message is sent
  - previously have to click on the 'send' button


https://github.com/user-attachments/assets/e17a4812-cc52-4bee-b52c-28cc01028e32

