### PR TITLE
Fix delete question and view history service bug

### DIFF
--- a/backend/history_service/controllers/historyController.js
+++ b/backend/history_service/controllers/historyController.js
@@ -63,7 +63,16 @@ const getAllAttemptedQuestions = async (req, res) => {
 
         // Combine question information with attempt date&time and code written
         const result = questionsAttempted.map(attempt => ({
-            ...questionMap[attempt.questionUid],
+            ...(questionMap[attempt.questionUid] || {
+                id: attempt.questionUid,
+                examples: [],
+                constraints: [],
+                title: "This question has been deleted from the database",
+                description: "Data not available",
+                difficulty: "Unknown",
+                dateCreated: "Unknown",
+                topics: ["Unknown"]
+            }),
             dateAttempted: attempt.dateAttempted,
             codeWritten: attempt.codeWritten
         }));


### PR DESCRIPTION
Currently, when a user attempts a question that is later deleted, and the user attempts to view their history of attempted questions, a bug prevents the user from seeing the old question and their code.

This needs to be addressed by ensuring that even if a question is deleted, the user sees a default placeholder text indicating that the question was removed from the database, while still being able to view their written code.

Thus, this PR aims to achieve the following:
* Fix delete question and view history service bug