### PR TITLE
Change refresh behaviour to not require user re-logging in everytime

### DIFF
--- a/frontend/src/components/custom/ProtectedRoute/ProtectedRoute.tsx
+++ b/frontend/src/components/custom/ProtectedRoute/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { getToken } from "@/lib/utils";
+import { auth } from "@/config/firebaseConfig";
 
 interface ProtectedRouteProps {
   children: JSX.Element;
@@ -11,14 +12,17 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
   useEffect(() => {
-    const fetchToken = async () => {
-      const token = await getToken();
-      if (token) {
-        setIsAuthenticated(true);
+    const unsubscribe = auth.onAuthStateChanged(async (user) => {
+      if (user) {
+        const token = await getToken();
+        setIsAuthenticated(!!token); // Set authentication status based on token
+      } else {
+        setIsAuthenticated(false);
       }
       setIsLoading(false);
-    };
-    fetchToken();
+    });
+
+    return () => unsubscribe(); // Clean up on unmount
   }, []);
 
   // Show a loading indicator while checking authentication status

--- a/frontend/src/views/CollabPageView.tsx
+++ b/frontend/src/views/CollabPageView.tsx
@@ -49,11 +49,11 @@ const customQuestion: Question = {
 
 const CollabPageView: React.FC = () => {
   const navigate = useNavigate();
-  const [code, setCode] = useState<string>(() => localStorage.getItem("code") || "");
+  const [code, setCode] = useState<string>(() => sessionStorage.getItem("code") || "");
   const [socket, setSocket] = useState<Socket | null>(null);
   const [message, setMessage] = useState(""); // For new message input
   const [messages, setMessages] = useState<{ username: string; message: string }[]>(() =>
-    JSON.parse(localStorage.getItem("messages") || "[]")
+    JSON.parse(sessionStorage.getItem("messages") || "[]")
   );
   const [userId, setUserId] = useState<string>("");
   const [username, setUsername] = useState<string>("");
@@ -177,17 +177,17 @@ const CollabPageView: React.FC = () => {
       if (socket) {
         socket.disconnect(); // Cleanup WebSocket connection on component unmount
       }
-      localStorage.removeItem("code");
-      localStorage.removeItem("messages");
+      sessionStorage.removeItem("code");
+      sessionStorage.removeItem("messages");
     };
   }, []);
 
   useEffect(() => {
-    localStorage.setItem("code", code);
+    sessionStorage.setItem("code", code);
   }, [code]);
 
   useEffect(() => {
-    localStorage.setItem("messages", JSON.stringify(messages));
+    sessionStorage.setItem("messages", JSON.stringify(messages));
   }, [messages]);
 
   const handleCodeChange = (newCode: string | undefined) => {

--- a/frontend/src/views/CollabPageView.tsx
+++ b/frontend/src/views/CollabPageView.tsx
@@ -49,12 +49,12 @@ const customQuestion: Question = {
 
 const CollabPageView: React.FC = () => {
   const navigate = useNavigate();
-  const [code, setCode] = useState("");
+  const [code, setCode] = useState<string>(() => localStorage.getItem("code") || "");
   const [socket, setSocket] = useState<Socket | null>(null);
   const [message, setMessage] = useState(""); // For new message input
-  const [messages, setMessages] = useState<
-    { username: string; message: string }[]
-  >([]);
+  const [messages, setMessages] = useState<{ username: string; message: string }[]>(() =>
+    JSON.parse(localStorage.getItem("messages") || "[]")
+  );
   const [userId, setUserId] = useState<string>("");
   const [username, setUsername] = useState<string>("");
   const [questionData, setQuestionData] = useState<Question>(customQuestion);
@@ -177,8 +177,18 @@ const CollabPageView: React.FC = () => {
       if (socket) {
         socket.disconnect(); // Cleanup WebSocket connection on component unmount
       }
+      localStorage.removeItem("code");
+      localStorage.removeItem("messages");
     };
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem("code", code);
+  }, [code]);
+
+  useEffect(() => {
+    localStorage.setItem("messages", JSON.stringify(messages));
+  }, [messages]);
 
   const handleCodeChange = (newCode: string | undefined) => {
     if (newCode === undefined) return; // if not code, do nothing


### PR DESCRIPTION
Currently, a page refresh would require the user to login again.

This should be changed so as to improve UX.

Thus, this pull request aims to do the following:
* Change refresh behaviour to not require user re-logging in everytime
* Persist code and messages sent in a collab session so that after a user refreshes, previous state of code and messages can be re-displayed

Note: to re tag milestone D7 if merging this PR in